### PR TITLE
Changes method name prefix to match class

### DIFF
--- a/Core/Source/BCKCode39Code.h
+++ b/Core/Source/BCKCode39Code.h
@@ -29,7 +29,7 @@
  @param error Optional output parameter to take an `NSError` in case the content cannot be encoded by this barcode class. Pass `nil` if not error information is not required.
  @return The requested BCKCode39Code (sub)class. Returns `nil` if the provided content cannot be encoded by the requested BCKCode39Code subclass, the error object will provide error details.
  */
-+ (instancetype)code93WithContent:(NSString *)content withModulo43:(BOOL)withModulo34 error:(NSError *__autoreleasing *)error;
++ (instancetype)code39WithContent:(NSString *)content withModulo43:(BOOL)withModulo34 error:(NSError *__autoreleasing *)error;
 
 /**
  Alternative initializer for subclasses of the BCKCode39Code class cluster. It will determine the correct subclass to use depending on whether the content includes full ASCII characters. A modulo 43 check digit character will NOT be included.
@@ -37,6 +37,6 @@
  @param error Optional output parameter to take an `NSError` in case the content cannot be encoded by this barcode class. Pass `nil` if not error information is not required.
  @return The requested BCKCode39Code (sub)class. Returns `nil` if the provided content cannot be encoded by the requested BCKCode39Code subclass, the error object will provide error details.
  */
-+ (instancetype)code93WithContent:(NSString *)content error:(NSError *__autoreleasing *)error;
++ (instancetype)code39WithContent:(NSString *)content error:(NSError *__autoreleasing *)error;
 
 @end

--- a/Core/Source/BCKCode39Code.m
+++ b/Core/Source/BCKCode39Code.m
@@ -18,25 +18,25 @@
 
 #pragma mark - Initialiser class methods
 
-+ (instancetype)code93WithContent:(NSString *)content error:(NSError *__autoreleasing *)error
++ (instancetype)code39WithContent:(NSString *)content error:(NSError *__autoreleasing *)error
 {
-	return [self code93WithContent:content withModulo43:NO error:error];
+	return [self code39WithContent:content withModulo43:NO error:error];
 }
 
-+ (instancetype)code93WithContent:(NSString *)content withModulo43:(BOOL)withModulo34 error:(NSError *__autoreleasing *)error
++ (instancetype)code39WithContent:(NSString *)content withModulo43:(BOOL)withModulo34 error:(NSError *__autoreleasing *)error
 {
 	BOOL isFullASCII = NO;
 	BOOL isNonFullASCII = NO;
 	
-	// Check if content can be encoded with a regular BCKCode93Code class, i.e. content does not include full ASCII characters
+	// Check if content can be encoded with a regular BCKCode39Code class, i.e. content does not include full ASCII characters
 	isNonFullASCII = [BCKCode39Code canEncodeContent:content error:nil];
 	if (!isNonFullASCII)
 	{
-		// Content contains characters that cannot be encoded using the BCKCode93Code class, now check if it contains full ASCII characters
+		// Content contains characters that cannot be encoded using the BCKCode39Code class, now check if it contains full ASCII characters
 		isFullASCII = [BCKCode39FullASCII canEncodeContent:content error:nil];
 	}
 	
-	// If both BOOLs are NO the content cannot be encoded by any of the BCKCode93Code classes, return nil
+	// If both BOOLs are NO the content cannot be encoded by any of the BCKCode39Code classes, return nil
 	if(!isNonFullASCII && !isFullASCII)
 	{
 		if (error)


### PR DESCRIPTION
In the `BCKCode39Code` class, the initializer method was named `code93WithContent:error:`. I think it was meant to be `code39WithContent:error:`