### PR TITLE
Declare deprecated init method NS_SWIFT_UNAVAILABLE

### DIFF
--- a/Core/Source/BCKCode.h
+++ b/Core/Source/BCKCode.h
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSUInteger, BCKCodeDrawingCaption)
  @param content The content string for the barcode.
  @return The requested BCKCode subclass. Returns `nil` if the content string cannot be encoded using the requested BCKCode subclass.
  */
-- (instancetype)initWithContent:(NSString *)content __attribute__((deprecated("use - [BCKCode initWithContent:error:] instead")));
+- (instancetype)initWithContent:(NSString *)content __attribute__((deprecated("use - [BCKCode initWithContent:error:] instead"))) NS_SWIFT_UNAVAILABLE("use `init(content:) throws` instead");
 
 @end
 


### PR DESCRIPTION
I'd suggest declaring this deprecated (and apparently unimplemented!) method as `NS_SWIFT_UNAVAILABLE`. The presence of this method declaration is interfering with Swift bridging.